### PR TITLE
Correct sorting of caged pets with the Sort by Item Type (Enhanced) method

### DIFF
--- a/Sorting/Order.lua
+++ b/Sorting/Order.lua
@@ -50,6 +50,7 @@ local allSortKeys = {
     "invertedCraftingQuality",
     "invertedItemID",
     "invertedItemCount",
+    "itemLink",
   },
   ["type-legacy"] = {
     "priority",


### PR DESCRIPTION

I noticed that with **Sorting by Item Type (Enhanced)**, caged pets do not get sorted at all (just like with the Blizz sort):

<details>
<summary>Screenshot: Failed Sorting by Type (Enhanced)</summary>
<img width="731" alt="sort_type copy-pty-fs8" src="https://github.com/tflo/fork-pr-Baganator/assets/1410282/380aab8b-282d-4545-8505-37ee7fb5d46b">
</details>

Here Blizz's sorting for comparison:

<details>
<summary>Screenshot: Failed Blizz Sorting</summary>
<img width="722" alt="sort_blizz copy-pty-fs8" src="https://github.com/tflo/fork-pr-Baganator/assets/1410282/578a3560-ca83-4722-875b-77e5d2a25aa4">
</details>

However, your **Sorting by Item Type (Basic)** *does* sort the pets correctly. See, for example, the highlighted groups of Iron Starlettes and Ikkys:

<details>
<summary>Screenshot: Correct Sorting by Type (Basic)</summary>
<img width="728" alt="sort_type_legacy copy HL-pty-fs8" src="https://github.com/tflo/fork-pr-Baganator/assets/1410282/c735b6d3-8fbb-495b-acc2-3568bf21dba7">
</details>

The problem here is that the sorting of non-pet items is flawed.

It seems the *only* effective sort key for caged pets is the **item link** (as it contains the species ID). This key is contained in your `type-legacy` keys list, but not in the `type` list.

If I add the `itemLink` key as last key to the `type` list, I get correct pet sorting, while the other items' "enhanced" sorting should not be negatively affected (at least I haven't noticed any negative sorting effects so far):

<details>
<summary>Screenshot: Correct Sorting by Type (Enhanced) + item link key</summary>
<img width="729" alt="sort_type_fixed-pty-fs8" src="https://github.com/tflo/fork-pr-Baganator/assets/1410282/3678140b-2da5-4cf7-b056-dabfe542f755">
</details>

Thanks for considering this small change! (Or anything equivalent or better.)

(To avoid redundancy, one could *probably* also replace the `invertedItemID` key with `itemLink` (or an inverted variant thereof.))

---

On a sidenote: 

The numbers with the pet levels (1 or 25 in the images) come from Kemayo's [Simple Item Levels addon](https://www.curseforge.com/wow/addons/simple-item-level).

It seems that Baganator can not extract the level from the pet cages.

If you want, I can open a separate issue for this. (But this is not really an "issue", since I'm using Simple Item Levels anyway, also because of the gear upgrade arrow and the other features.)